### PR TITLE
Implement time restriction middleware and prevent id_survey updates

### DIFF
--- a/backend/config/init.sql
+++ b/backend/config/init.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 -- Table SurveysResponse
 CREATE TABLE IF NOT EXISTS surveys (
     id_survey UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-    response VARCHAR(11) NOT NULL, -- Risposta, massimo 11 caratteri
+    response VARCHAR(11) NOT NULL , -- Risposta, massimo 11 caratteri
     date_created TIMESTAMP DEFAULT NOW()
 );
 
@@ -41,3 +41,23 @@ CREATE TABLE IF NOT EXISTS matches (
     date_created TIMESTAMP DEFAULT NOW(),
     PRIMARY KEY (email_user1, email_user2)
 );
+
+
+-- Trigger
+
+CREATE OR REPLACE FUNCTION prevent_id_survey_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.id_survey IS NOT NULL AND NEW.id_survey IS DISTINCT FROM OLD.id_survey THEN
+        RAISE EXCEPTION 'id_survey può essere aggiornato solo una volta da NULL a un valore non NULL.';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_prevent_id_survey_update ON users;
+
+CREATE TRIGGER trigger_prevent_id_survey_update
+BEFORE UPDATE OF id_survey ON users
+FOR EACH ROW
+EXECUTE FUNCTION prevent_id_survey_update();

--- a/backend/internal/server/middleware/time_restriction.go
+++ b/backend/internal/server/middleware/time_restriction.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const TIME_FORMAT = "2006-01-02 15:04:05"
+
+const DEADLINE = "2025-02-13 23:59:59"
+
+func TimeRestrictionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		currentTime := time.Now().UTC()
+		deadlineTime, err := time.Parse(TIME_FORMAT, DEADLINE)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to parse deadline time")
+			c.JSON(500, gin.H{"error": "Internal server error"})
+			c.Abort()
+			return
+		}
+
+		log.Debug().Str("currentTime", currentTime.String()).Str("deadlineTime", deadlineTime.String()).Msg("TimeRestrictionMiddleware")
+
+		if currentTime.After(deadlineTime) {
+			c.JSON(400, gin.H{"error": "You cannot edit your profile after the deadline"})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/backend/internal/server/routes/protected.go
+++ b/backend/internal/server/routes/protected.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"backend/internal/server/middleware"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -10,8 +12,8 @@ func registerProtectedRoutes(r *gin.RouterGroup, h *Handler) {
 	r.GET("/getPhoto", h.GetPhoto)
 	r.GET("/getMatches", h.GetMatches)
 
-	r.POST("/addSurvey", h.AddSurvey)
-	r.POST("/addPhoto", h.AddPhoto)
-	r.POST("/addUserInfo", h.AddUserInfo)
-	r.POST("/setLike", h.SetLike)
+	r.POST("/addSurvey", middleware.TimeRestrictionMiddleware(), h.AddSurvey)
+	r.POST("/addPhoto", middleware.TimeRestrictionMiddleware(), h.AddPhoto)
+	r.POST("/addUserInfo", middleware.TimeRestrictionMiddleware(), h.AddUserInfo)
+	r.POST("/setLike", middleware.TimeRestrictionMiddleware(), h.SetLike)
 }


### PR DESCRIPTION
Introduce middleware to restrict profile editing after a specified deadline and add a trigger to prevent updates to the id_survey field once set.